### PR TITLE
Add RAG embedding engine as install option

### DIFF
--- a/conf/.env
+++ b/conf/.env
@@ -22,6 +22,8 @@ WEBUI_NAME="Open WebUI for YunoHost"
 PORT=__PORT__
 DATA_DIR="__DATA_DIR__"
 ENABLE_SIGNUP=false
+# RAG embedding engine: 'ollama', 'openai', or '' (local sentence-transformers)
+RAG_EMBEDDING_ENGINE=__RAG_EMBEDDING_ENGINE__
 #LDAP
 ENABLE_LDAP=true
 LDAP_SERVER_LABEL='YunoHost LDAP'

--- a/manifest.toml
+++ b/manifest.toml
@@ -50,6 +50,15 @@ ram.runtime = "2G"
     [install.admin]
     type = "user"
 
+    [install.rag_embedding_engine]
+    ask.en = "Embedding engine for RAG (document search)"
+    ask.fr = "Moteur d'embedding pour le RAG (recherche documentaire)"
+    help.en = "Use 'ollama' if Ollama is running locally (avoids downloading a ~1GB model). Use 'openai' for OpenAI-compatible APIs (configure the API key in the admin panel after install). Leave empty to use a built-in local model (slow first start)."
+    help.fr = "Utilisez 'ollama' si Ollama tourne localement (évite le téléchargement d'un modèle de ~1Go). Utilisez 'openai' pour les API compatibles OpenAI (configurez la clé API dans le panneau d'administration après l'installation). Laissez vide pour utiliser un modèle local intégré (premier démarrage lent)."
+    type = "select"
+    choices = ["ollama", "openai", ""]
+    default = "ollama"
+
 [resources]
 
     [resources.sources]

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -17,6 +17,11 @@ ynh_script_progression "Stopping $app's systemd service..."
 ynh_systemctl --service="$app" --action="stop"
 
 #=================================================
+# ENSURE DOWNWARD COMPATIBILITY
+#=================================================
+ynh_app_setting_set_default --key=rag_embedding_engine --value=""
+
+#=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
 #=================================================
 


### PR DESCRIPTION
Adds a YunoHost install question for the RAG embedding engine (ollama/openai/local). Defaults to ollama to avoid downloading a ~1GB sentence-transformers model from HuggingFace on first start. Users can change this later in the Open WebUI admin panel.

## Problem

- Didn't want the local models to be downloaded on my installation.

## Solution

- Allow configuring the embedding engine.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
